### PR TITLE
Fix: Redirect external links to open in a new tab

### DIFF
--- a/master/index.html
+++ b/master/index.html
@@ -787,9 +787,9 @@ code span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warni
 <p><img src="figures/PecanLogo.png" width="50%" height="50%" style="display: block; margin: auto;" /></p>
 <p><strong>Our Mission:</strong></p>
 <p><strong>Develop and promote accessible tools for reproducible ecosystem modeling and forecasting</strong></p>
-<p><a href="http://pecanproject.github.io/">PEcAn Website</a></p>
-<p><a href="https://join.slack.com/t/pecanproject/shared_invite/enQtMzkyODUyMjQyNTgzLWEzOTM1ZjhmYWUxNzYwYzkxMWVlODAyZWQwYjliYzA0MDA0MjE4YmMyOTFhMjYyMjYzN2FjODE4N2Y4YWFhZmQ">Public Chat Room</a></p>
-<p><a href="https://github.com/PecanProject/pecan">Github Repository</a></p>
+<p><a href="http://pecanproject.github.io/" target="_blank" rel="noopener noreferrer">PEcAn Website</a></p>
+<p><a href="https://join.slack.com/t/pecanproject/shared_invite/enQtMzkyODUyMjQyNTgzLWEzOTM1ZjhmYWUxNzYwYzkxMWVlODAyZWQwYjliYzA0MDA0MjE4YmMyOTFhMjYyMjYzN2FjODE4N2Y4YWFhZmQ" target="_blank" rel="noopener noreferrer">Public Chat Room</a></p>
+<p><a href="https://github.com/PecanProject/pecan" target="_blank" rel="noopener noreferrer">Github Repository</a></p>
 <html>
 <head>
 <style>


### PR DESCRIPTION
Issue:
External links at the bottom of the iframe-based page were not working due to restrictions caused by Content Security Policy (CSP) headers, preventing interaction within the iframe.

Fix:
Updated the links to include target="_blank" to ensure they open in a new tab.
Added rel="noopener noreferrer" for improved security and to prevent potential access to the original page via window.opener.

Impact:
External links now open in a new tab, bypassing iframe restrictions, and provide a seamless user experience without security risks.